### PR TITLE
chore: Add .env to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,47 @@
+# Environment variables
+.env
+
+# Python cache
+__pycache__/
+*.py[cod]
+*$py.class
+
+# IDE and editor directories
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# Logs
+logs/
+*.log
+
+# Python virtual environment
+venv/
+env/
+.venv/
+
+# OS generated files
+.DS_Store
+Thumbs.db
+
+# Coverage reports
+.coverage
+coverage.xml
+htmlcov/
+
+# Build artifacts
+dist/
+build/
+*.egg-info/
+*.egg
+ MANIFEST
+
+# Jupyter Notebook checkpoints
+.ipynb_checkpoints
+
+# Ruff cache
+.ruff_cache/
+
+# Pytest cache
+.pytest_cache/


### PR DESCRIPTION
Ensures that the .env file, often containing environment-specific configurations or secrets, is ignored by Git. Also added common Python, IDE, and cache patterns to the .gitignore file.