### PR TITLE
fix: Correct Dockerfile syntax for UVICORN_WORKERS default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,8 @@ FROM python:3.11-slim
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     PATH="/home/appuser/.local/bin:$PATH" \
-    PYTHONPATH=/app \
-    UVICORN_WORKERS=${UVICORN_WORKERS:-4} # Default to 4 if not set
+    PYTHONPATH=/app
+    # UVICORN_WORKERS will be handled by CMD's default shell expansion
 
 WORKDIR /app
 
@@ -36,5 +36,5 @@ USER appuser
 
 EXPOSE 8100
 
-# CMD will use $UVICORN_WORKERS set by ENV or docker-compose
-CMD uvicorn main:app --host 0.0.0.0 --port 8100 --workers "$UVICORN_WORKERS"
+# Use sh -c to allow shell expansion for default worker count
+CMD ["sh", "-c", "exec uvicorn main:app --host 0.0.0.0 --port 8100 --workers ${UVICORN_WORKERS:-4}"]


### PR DESCRIPTION
Removes the `ENV UVICORN_WORKERS=...` line that was causing a syntax error in GitHub Actions Docker builds.
Modifies the `CMD` to use `sh -c "exec ... --workers ${UVICORN_WORKERS:-4}"` to correctly apply a default value for the worker count if the UVICORN_WORKERS environment variable is not set.