### PR TITLE
fix: Ensure .env file exists in Docker image for runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ WORKDIR /app
 # Create a non-root user and group
 RUN groupadd -r appgroup && useradd --no-log-init -r -g appgroup -d /home/appuser -s /sbin/nologin appuser && \
     mkdir -p /home/appuser/.local && chown -R appuser:appgroup /home/appuser && \
+    touch /app/.env && \
     mkdir -p /app/logs && chown -R appuser:appgroup /app && \
     mkdir -p /app/static # Static files will be copied and owned by appuser later
 


### PR DESCRIPTION
Adds a step to the Dockerfile to create an empty .env file in the /app directory. This prevents FileNotFoundError from slowapi/starlette.config when the application starts, as it expects a .env file to be present even if not strictly used for configuration values by slowapi's default setup. The file is created with appropriate ownership for the appuser.