### PR TITLE
Fix: Update Dockerfile and logger for robust environment support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,12 @@ FROM python:3.11-slim AS builder
 WORKDIR /app
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends gcc python3-dev && \
+    apt-get install -y --no-install-recommends gcc python3-dev apt-utils && \
     rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt .
-RUN pip install --user --no-cache-dir -r requirements.txt
+RUN python -m pip install --upgrade pip && \
+    pip install --user --no-cache-dir -r requirements.txt
 
 # Stage 2: Runtime
 FROM python:3.11-slim

--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 import os
 import json
+import sys # Added import
 import uuid
 import time
 import asyncio
@@ -124,7 +125,7 @@ app.mount("/static", StaticFiles(directory="static"), name="static")
 
 # Configure logger to only use stderr
 logger.configure(handlers=[
-    {"sink": "stderr", "level": "INFO"},
+    {"sink": sys.stderr, "level": "INFO"},
 ])
 
 cache = cachetools.TTLCache(maxsize=get_sync_initial_cache_maxsize(), ttl=300)


### PR DESCRIPTION
- Dockerfile: Added apt-utils to prevent debconf warnings and upgraded pip.
- main.py: Changed Loguru sink from 'stderr' string to `sys.stderr` object to prevent OSError on read-only filesystems at startup.
- All existing tests pass with these changes.