### PR TITLE
Feat: Fix WebSocket test and add custom error pages

### DIFF
--- a/static/403.html
+++ b/static/403.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="fa" dir="rtl">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>دسترسی ممنوع (403)</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link href="https://cdn.jsdelivr.net/gh/rastikerdar/vazirmatn@v33.003/Vazirmatn-font-face.css" rel="stylesheet" type="text/css" />
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    fontFamily: {
+                        'vazir': ['Vazirmatn', 'sans-serif'],
+                    },
+                },
+            },
+        }
+    </script>
+    <style type="text/tailwindcss">
+        @layer base {
+            body {
+                font-family: theme('fontFamily.vazir');
+            }
+        }
+    </style>
+</head>
+<body class="bg-gray-900 text-gray-100 font-vazir flex flex-col items-center justify-center min-h-screen p-6">
+    <div class="text-center">
+        <svg xmlns="http://www.w3.org/2000/svg" class="mx-auto mb-6 h-24 w-24 text-red-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636M12 18.75a.75.75 0 01.75-.75h.008a.75.75 0 01.75.75v.008a.75.75 0 01-.75.75H12.75a.75.75 0 01-.75-.75V18.75zM12 12.75a.75.75 0 01.75-.75h.008a.75.75 0 01.75.75v.008a.75.75 0 01-.75.75H12.75a.75.75 0 01-.75-.75V12.75zM12 6.75a.75.75 0 01.75-.75h.008a.75.75 0 01.75.75v.008a.75.75 0 01-.75.75H12.75a.75.75 0 01-.75-.75V6.75z" />
+            <path stroke-linecap="round" stroke-linejoin="round" d="M12 3v.01M12 6l-.01 6.01M12 12.01l.01 6M12 18.01V21" />
+             <path stroke-linecap="round" stroke-linejoin="round" d="M12 9a3 3 0 100-6 3 3 0 000 6zM12 15a3 3 0 100-6 3 3 0 000 6z" />
+            <path stroke-linecap="round" stroke-linejoin="round" d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636" /> <!-- Simple X -->
+             <path stroke-linecap="round" stroke-linejoin="round" d="M12 15.75a.75.75 0 01.75.75v.008a.75.75 0 01-.75.75h-.008a.75.75 0 01-.75-.75v-.008a.75.75 0 01.75-.75z M12 9.75A.75.75 0 0112.75 9h.008a.75.75 0 01.75.75v.008a.75.75 0 01-.75.75h-.008A.75.75 0 0112 9.75v-.008z" /> <!-- dots -->
+            <path stroke-linecap="round" stroke-linejoin="round" d="M12 6.75V17.25" /> <!-- vertical line -->
+            <path stroke-linecap="round" stroke-linejoin="round" d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636" />
+        </svg>
+        <h1 class="text-6xl font-bold text-red-500 mb-4">403</h1>
+        <h2 class="text-3xl sm:text-4xl font-semibold text-gray-200 mb-6">دسترسی ممنوع</h2>
+        <p class="text-lg text-gray-400 mb-8 max-w-md">
+            متاسفانه شما مجوز دسترسی به این صفحه یا منبع را ندارید. لطفا با پشتیبانی تماس بگیرید اگر فکر می‌کنید این یک خطا است.
+        </p>
+        <a href="/" class="bg-red-600 hover:bg-red-700 text-white font-semibold py-3 px-6 rounded-lg text-lg transition-all duration-150 ease-in-out transform hover:scale-105">
+            بازگشت به صفحه اصلی
+        </a>
+    </div>
+
+    <footer class="absolute bottom-6 text-gray-500 text-sm">
+        <p id="copyright-info-403">© <span id="year-403"></span> MovtiGroup. Designed by Taha Tehrani Nasab - <a href="http://ththt.ir" target="_blank" rel="noopener noreferrer" class="hover:text-gray-300 underline">ththt.ir</a></p>
+    </footer>
+    <script>
+        document.getElementById('year-403').textContent = new Date().getFullYear();
+    </script>
+</body>
+</html>

--- a/static/500.html
+++ b/static/500.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="fa" dir="rtl">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>خطای داخلی سرور (500)</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link href="https://cdn.jsdelivr.net/gh/rastikerdar/vazirmatn@v33.003/Vazirmatn-font-face.css" rel="stylesheet" type="text/css" />
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    fontFamily: {
+                        'vazir': ['Vazirmatn', 'sans-serif'],
+                    },
+                },
+            },
+        }
+    </script>
+    <style type="text/tailwindcss">
+        @layer base {
+            body {
+                font-family: theme('fontFamily.vazir');
+            }
+        }
+    </style>
+</head>
+<body class="bg-gray-900 text-gray-100 font-vazir flex flex-col items-center justify-center min-h-screen p-6">
+    <div class="text-center">
+        <svg xmlns="http://www.w3.org/2000/svg" class="mx-auto mb-6 h-24 w-24 text-orange-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z" />
+        </svg>
+        <h1 class="text-6xl font-bold text-orange-500 mb-4">500</h1>
+        <h2 class="text-3xl sm:text-4xl font-semibold text-gray-200 mb-6">خطای داخلی سرور</h2>
+        <p class="text-lg text-gray-400 mb-8 max-w-md">
+            متاسفانه یک مشکل غیرمنتظره در سرور رخ داده است. تیم ما از این موضوع مطلع شده است. لطفا کمی بعد دوباره تلاش کنید یا با پشتیبانی تماس بگیرید.
+        </p>
+        <a href="/" class="bg-orange-600 hover:bg-orange-700 text-white font-semibold py-3 px-6 rounded-lg text-lg transition-all duration-150 ease-in-out transform hover:scale-105">
+            بازگشت به صفحه اصلی
+        </a>
+    </div>
+
+    <footer class="absolute bottom-6 text-gray-500 text-sm">
+        <p id="copyright-info-500">© <span id="year-500"></span> MovtiGroup. Designed by Taha Tehrani Nasab - <a href="http://ththt.ir" target="_blank" rel="noopener noreferrer" class="hover:text-gray-300 underline">ththt.ir</a></p>
+    </footer>
+    <script>
+        document.getElementById('year-500').textContent = new Date().getFullYear();
+    </script>
+</body>
+</html>

--- a/static/script.js
+++ b/static/script.js
@@ -8,71 +8,160 @@ document.addEventListener('DOMContentLoaded', () => {
   const responseContainer = document.getElementById('ws-response');
   
   let ws = null;
+  let currentMessageStreamElement = null;
+
+  function updateWsStatus(message, isError = false, isConnected = false) {
+    wsStatus.textContent = `وضعیت: ${message}`;
+    // Remove old Tailwind classes related to status color, then add new ones
+    wsStatus.classList.remove('bg-green-700', 'text-green-100', 'bg-red-700', 'text-red-100', 'bg-yellow-700', 'text-yellow-100', 'bg-gray-700', 'text-gray-300');
+    if (isConnected) {
+        wsStatus.classList.add('bg-green-700', 'text-green-100'); // Connected
+    } else if (isError) {
+        wsStatus.classList.add('bg-red-700', 'text-red-100'); // Error
+    } else {
+        wsStatus.classList.add('bg-gray-700', 'text-gray-300'); // Default / Disconnected
+    }
+  }
+
+  function setUIConnected(connected) {
+    wsConnectBtn.disabled = connected;
+    wsDisconnectBtn.disabled = !connected;
+    apiKeyInput.disabled = connected;
+    messageInput.disabled = !connected;
+    sendBtn.disabled = !connected;
+  }
+
+  // Initial UI State
+  setUIConnected(false);
+  updateWsStatus('قطع');
   
   // WebSocket connection
   wsConnectBtn.addEventListener('click', () => {
-    const apiKey = apiKeyInput.value.trim();
+    let apiKey = apiKeyInput.value.trim();
     
     if (!apiKey) {
       alert('لطفا API Key را وارد کنید');
       return;
     }
+
+    if (!apiKey.toLowerCase().startsWith('bearer ')) {
+        apiKey = `Bearer ${apiKey}`;
+    }
     
-    // Replace with your actual WebSocket URL
-    ws = new WebSocket(`ws://${window.location.host}/ws/v1/chat/completions`);
+    responseContainer.innerHTML = '<p class="text-gray-500">در حال اتصال...</p>'; // Clear previous messages
+    currentMessageStreamElement = null; // Reset stream element
+
+    // Ensure correct WebSocket protocol (ws or wss)
+    const wsProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+    ws = new WebSocket(`${wsProtocol}//${window.location.host}/ws/v1/chat/completions`);
+    updateWsStatus('در حال اتصال...');
     
     ws.onopen = () => {
-      wsStatus.textContent = 'متصل';
-      wsStatus.className = 'status-connected';
+      setUIConnected(true);
+      updateWsStatus('متصل', false, true);
       
-      // Send authentication first
-      ws.send(JSON.stringify({
-        api_key: apiKey
-      }));
+      ws.send(JSON.stringify({ api_key: apiKey }));
+      // Optionally, clear the initial "در حال اتصال..." message or add a "Connected" message
+      responseContainer.innerHTML = '<p class="text-green-400">اتصال برقرار شد. می‌توانید پیام ارسال کنید.</p>';
     };
     
     ws.onmessage = (event) => {
-      try {
-        const data = JSON.parse(event.data);
-        
-        // Create message element
-        const messageEl = document.createElement('div');
-        messageEl.className = 'message';
-        
-        if (data.choices && data.choices[0] && data.choices[0].delta && data.choices[0].delta.content) {
-          messageEl.textContent = data.choices[0].delta.content;
-        } else if (data.error) {
-          messageEl.textContent = `خطا: ${data.error}`;
-          messageEl.className = 'message error';
-        } else {
-          messageEl.textContent = JSON.stringify(data, null, 2);
+        if (responseContainer.querySelector('.text-gray-500, .text-green-400, .text-red-400')) {
+             // Clear initial status messages like "Connecting...", "Connected", "Error"
+            if (responseContainer.innerHTML.includes("پاسخ‌ها اینجا نمایش داده می‌شوند") ||
+                responseContainer.innerHTML.includes("در حال اتصال") ||
+                responseContainer.innerHTML.includes("اتصال برقرار شد") ||
+                responseContainer.innerHTML.includes("خطا")) {
+                responseContainer.innerHTML = '';
+            }
         }
-        
-        responseContainer.appendChild(messageEl);
-        responseContainer.scrollTop = responseContainer.scrollHeight;
-      } catch (e) {
-        console.error('Error parsing WebSocket message:', e);
-      }
+
+        try {
+            const data = JSON.parse(event.data);
+            let messageText = '';
+            let isError = false;
+
+            if (data.error) {
+                messageText = `خطا: ${data.error}`;
+                isError = true;
+                currentMessageStreamElement = null; // Stop appending to any previous stream
+            } else if (data.choices && data.choices[0] && data.choices[0].delta && typeof data.choices[0].delta.content === 'string') {
+                messageText = data.choices[0].delta.content;
+            } else if (data.choices && data.choices[0] && data.choices[0].message && typeof data.choices[0].message.content === 'string') { // Non-streamed full response
+                messageText = data.choices[0].message.content;
+                currentMessageStreamElement = null;
+            } else {
+                // Fallback for other JSON structures or if no content/error
+                messageText = JSON.stringify(data, null, 2);
+                currentMessageStreamElement = null;
+            }
+
+            if (messageText) {
+                if (!isError && data.choices && data.choices[0] && data.choices[0].delta) { // It's a stream chunk
+                    if (!currentMessageStreamElement) {
+                        currentMessageStreamElement = document.createElement('div');
+                        currentMessageStreamElement.classList.add('text-gray-200', 'p-2', 'my-1', 'rounded', 'bg-gray-600', 'whitespace-pre-wrap');
+                        responseContainer.appendChild(currentMessageStreamElement);
+                    }
+                    currentMessageStreamElement.textContent += messageText;
+                } else { // Full message or error
+                    const messageEl = document.createElement('div');
+                    messageEl.classList.add('p-2', 'my-1', 'rounded', 'whitespace-pre-wrap');
+                    messageEl.textContent = messageText;
+                    if (isError) {
+                        messageEl.classList.add('text-red-400', 'bg-red-900', 'bg-opacity-30');
+                    } else {
+                        messageEl.classList.add('text-gray-200', 'bg-gray-600');
+                    }
+                    responseContainer.appendChild(messageEl);
+                    currentMessageStreamElement = null; // Reset for next full message
+                }
+            }
+
+            responseContainer.scrollTop = responseContainer.scrollHeight;
+        } catch (e) {
+            console.error('Error processing WebSocket message:', e, 'Raw data:', event.data);
+            // Display raw data if JSON parsing fails and it's not an empty string
+            if (event.data && event.data.trim() !== "") {
+                const errorDisplay = document.createElement('div');
+                errorDisplay.classList.add('text-red-400', 'bg-red-900', 'bg-opacity-30', 'p-2', 'my-1', 'rounded', 'whitespace-pre-wrap');
+                errorDisplay.textContent = `خطا در پردازش پیام: ${event.data}`;
+                responseContainer.appendChild(errorDisplay);
+                responseContainer.scrollTop = responseContainer.scrollHeight;
+            }
+        }
     };
     
     ws.onerror = (error) => {
       console.error('WebSocket Error:', error);
-      wsStatus.textContent = 'خطا در اتصال';
-      wsStatus.className = 'status-error';
+      updateWsStatus('خطا در اتصال', true);
+      setUIConnected(false);
+      responseContainer.innerHTML = `<p class="text-red-400">خطا در اتصال WebSocket. جزئیات در کنسول مرورگر.</p>`;
+      currentMessageStreamElement = null;
     };
     
-    ws.onclose = () => {
-      wsStatus.textContent = 'قطع ارتباط';
-      wsStatus.className = 'status-disconnected';
+    ws.onclose = (event) => {
+      updateWsStatus(`قطع (کد: ${event.code})`);
+      setUIConnected(false);
+      if (!event.wasClean && event.code !== 1000) { // 1000 is normal closure
+          responseContainer.innerHTML = `<p class="text-yellow-400">اتصال به طور غیرمنتظره قطع شد (کد: ${event.code}).</p>`;
+      } else if (responseContainer.innerHTML.includes("اتصال برقرار شد")) {
+          // If only "Connected" message was there, replace it or add to it
+          responseContainer.innerHTML = '<p class="text-gray-500">ارتباط قطع شد.</p>';
+      }
+      currentMessageStreamElement = null;
     };
   });
   
   // Disconnect WebSocket
   wsDisconnectBtn.addEventListener('click', () => {
     if (ws) {
-      ws.close();
-      ws = null;
+      ws.close(1000, "User disconnected"); // Send a normal closure code
     }
+    setUIConnected(false); // Explicitly set UI state on manual disconnect
+    updateWsStatus('قطع');
+    responseContainer.innerHTML = '<p class="text-gray-500">پاسخ‌ها اینجا نمایش داده می‌شوند...</p>';
+    currentMessageStreamElement = null;
   });
   
   // Send message


### PR DESCRIPTION
Phase 1 of frontend and error handling improvements:

- Debugged and significantly improved the interactive WebSocket test in static/script.js and static/index.html. This includes better UI state management, API key formatting, connection/disconnection feedback, message streaming display, and error handling.
- Created new static/403.html and static/500.html pages, styled with Tailwind CSS, Vazir font, and a dark theme, providing user-friendly messages for these HTTP errors.
- Updated error handlers in main.py:
  - http_exception_handler now serves custom HTML for 403 and 404 errors, with content negotiation to return JSON for API clients.
  - Added a new generic_exception_handler to serve the custom 500.html for unhandled server-side exceptions.