### PR TITLE
Fix: Correct WebSocket auth and debug copy functionality

### DIFF
--- a/main.py
+++ b/main.py
@@ -302,10 +302,11 @@ async def _handle_websocket_chat(websocket: WebSocket, raw_api_key: str, tier_fo
 @ws_router_v1.websocket("/chat/completions")
 async def ws_v1_chat_completions(websocket: WebSocket):
     raw_api_key_from_ws = ""
+    await websocket.accept() # Accept the connection first
     try:
         auth_data = await websocket.receive_json()
         api_key_header_sim = auth_data.get("api_key")
-        if not api_key_header_sim: await websocket.send_json({"error": "API key is required as first message: {\"api_key\": \"Bearer <YOUR_KEY>\"}"}); await websocket.close(); return
+        if not api_key_header_sim: await websocket.send_json({"error": "API key is required as first message: {\"api_key\": \"Bearer <YOUR_KEY>\"}"}); await websocket.close(code=4001); return # Use custom close code
         if not api_key_header_sim.startswith("Bearer "): await websocket.send_json({"error": "Invalid API Key format. Expected Bearer token."}); await websocket.close(); return
         raw_api_key_from_ws = api_key_header_sim.replace("Bearer ", "").strip()
         if not raw_api_key_from_ws: await websocket.send_json({"error": "API Key is empty."}); await websocket.close(); return
@@ -326,10 +327,11 @@ async def ws_v1_chat_completions(websocket: WebSocket):
 @ws_router_v2.websocket("/chat/completions")
 async def ws_v2_chat_completions(websocket: WebSocket):
     raw_api_key_from_ws = ""
+    await websocket.accept() # Accept the connection first
     try:
         auth_data = await websocket.receive_json()
         api_key_header_sim = auth_data.get("api_key")
-        if not api_key_header_sim: await websocket.send_json({"error": "API key is required as first message: {\"api_key\": \"Bearer <YOUR_KEY>\"}"}); await websocket.close(); return
+        if not api_key_header_sim: await websocket.send_json({"error": "API key is required as first message: {\"api_key\": \"Bearer <YOUR_KEY>\"}"}); await websocket.close(code=4001); return # Use custom close code
         if not api_key_header_sim.startswith("Bearer "): await websocket.send_json({"error": "Invalid API Key format. Expected Bearer token."}); await websocket.close(); return
         raw_api_key_from_ws = api_key_header_sim.replace("Bearer ", "").strip()
         if not raw_api_key_from_ws: await websocket.send_json({"error": "API Key is empty."}); await websocket.close(); return

--- a/static/script.js
+++ b/static/script.js
@@ -197,18 +197,36 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // Copy to clipboard for code blocks
   $('.copy-btn').on('click', function() {
+    console.log("Copy button clicked", this);
     const codeBlock = $(this).siblings('pre').find('code');
+    console.log("Found code block element:", codeBlock.get(0)); // Log the DOM element
+
+    if (codeBlock.length === 0) {
+        console.error("Could not find code block for button:", this);
+        alert('خطا: بلوک کد برای کپی یافت نشد.');
+        return;
+    }
+
     const textToCopy = codeBlock.text();
+    console.log("Text to copy:", textToCopy);
+
+    if (!textToCopy.trim()) {
+        console.warn("Attempting to copy empty or whitespace-only text.");
+        // Optionally alert the user or just do nothing
+        // alert('محتوایی برای کپی وجود ندارد.');
+        // return;
+    }
 
     navigator.clipboard.writeText(textToCopy).then(() => {
       const originalText = $(this).text();
       $(this).text('کپی شد!');
+      console.log('Text copied successfully!');
       setTimeout(() => {
         $(this).text(originalText);
       }, 2000);
     }).catch(err => {
       console.error('Failed to copy text: ', err);
-      alert('خطا در کپی متن.');
+      alert('خطا در کپی متن. ممکن است نیاز به مجوز دسترسی به کلیپ‌بورد باشد یا در محیط ناامن (غیر HTTPS) اجرا شده باشد.');
     });
   });
 


### PR DESCRIPTION
- main.py: Moved `await websocket.accept()` to the beginning of WebSocket handlers to resolve 'Need to call accept first' error and prevent client-side 1006 disconnections.
- static/script.js: Added extensive console logging and checks to the copy-to-clipboard feature to aid in debugging its functionality. The selector logic was reviewed and appears correct.